### PR TITLE
improve artifact upload and add logs to step summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,30 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
-          path: ${{ env.ARTIFACTS_PATH }}
+          path: ${{ env.ARTIFACTS_PATH }}/*.zip
+
+      - name: Add logs to job summary
+        run: |
+          $logFiles = Get-ChildItem -Path "${{ env.ARTIFACTS_PATH }}\Logs" -Recurse -Filter *.log
+          $summary = "# Logs `n`n"
+          if ($logFiles) {
+              foreach ($logFile in $logFiles) {
+                  $content = Get-Content -Path $logFile
+                  $summary += "## $logFile `n"
+                  foreach ($line in $content) {
+                      # if the line consists only of = or - characters 
+                      # (which would be interpreted as a setext heading 
+                      # (https://github.github.com/gfm/#setext-headings)), 
+                      # add a new line before it
+                      if ($line -match "^[=-]+$") {
+                          $summary += "`n$line`n"
+                      } else {
+                        $summary += $line + "`n"
+                      } 
+                  }
+              }
+          }
+          $summary >> $env:GITHUB_STEP_SUMMARY
           
    PostProcess: 
     if: ${{ !cancelled() }}


### PR DESCRIPTION
Just a bit of housekeeping to remove the log files from the artifact created by the build action and instead add them to the step summary of the action run.