### PR TITLE
avoid nested zip by uploading unzipped package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,14 @@ jobs:
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
       
+      - name: Unzip package
+        run: Expand-Archive -Path ${{ env.ARTIFACTS_PATH }}/*.zip -Destination ${{ env.ARTIFACTS_PATH }}/${{ env.PACKAGE_NAME }}
+      
       - name: Publish artifacts  
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
-          path: ${{ env.ARTIFACTS_PATH }}/*.zip
+          path: ${{ env.ARTIFACTS_PATH }}/${{ env.PACKAGE_NAME }}
 
       - name: Add logs to job summary
         run: |


### PR DESCRIPTION
Same change as for https://github.com/ameyer505/D365FOAdminToolkit/issues/51:
The artifact uploaded to the build action is now a .zip file that can directly uploaded into LCS. Previously, the .zip file contained another .zip file. Only the inner .zip file was recognized as a valid package file by LCS.